### PR TITLE
Updated RabbitMqConfiguration

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/ipc/impl/RabbitMqConfiguration.java
+++ b/src/main/java/edu/stanford/protege/webprotege/ipc/impl/RabbitMqConfiguration.java
@@ -62,7 +62,7 @@ public class RabbitMqConfiguration {
 
 
     @Autowired(required = false)
-    private List<CommandHandler<? extends Request, ? extends Response>> handlers;
+    private List<CommandHandler<? extends Request, ? extends Response>> handlers = new ArrayList<>();
 
 
     @Autowired
@@ -188,7 +188,7 @@ public class RabbitMqConfiguration {
             }
             channel.queueBind(getCommandResponseQueue(), COMMANDS_EXCHANGE, getCommandResponseQueue());
 
-        } catch (Exception e) {
+        } catch (IOException |TimeoutException e) {
             logger.error("Error initialize bindings", e);
         }
     }


### PR DESCRIPTION
- Narrowed exceptions caught to be more specific (Instead of catching Exception, catching IOException and TimeoutException).  @alexsilaghi please review this.
- Set default value for handlers to be an empty array